### PR TITLE
import curations as well as annotations

### DIFF
--- a/inceptalytics/utils.py
+++ b/inceptalytics/utils.py
@@ -53,7 +53,7 @@ def annotation_info_from_xmi_zip(project_fp: str):
     """
     annotations = []
     with ZipFile(project_fp) as project_zip:
-        regex = re.compile('.*annotation/.*/(?!\._).*zip$')
+        regex = re.compile('.*(annotation|curation)/.*/(?!\._).*zip$')
         annotation_fps = (fp for fp in project_zip.namelist() if regex.match(fp))
 
         typesystem = None


### PR DESCRIPTION
Hello, I would like to propose a small update which makes the package load curation too. With this change the CURATION_USER and their annotations is included among annotators.

It worked on our project, but I am not familiar with all the details of the package, so feel free to reject if it doesn't make sense for some reason.